### PR TITLE
Handle FieldFile-like instance in FileContentTypeValidator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,16 @@ env:
   matrix:
   - DJANGO="django>=1.10.1,<1.11.0"
   - DJANGO="django>=1.11.0,<1.12.0"
+  - DJANGO="django>=2.0,<2.1"
+  - DJANGO="django>=2.1,<2.2"
+  - DJANGO="django>=2.2,<2.3"
+
+matrix:
+  exclude:
+    - python: '3.4'
+      env: DJANGO="django>=2.1,<2.2"
+    - python: '3.4'
+      env: DJANGO="django>=2.2,<2.3"
 
 script:
   - sudo apt-get install clamav-daemon clamav-freshclam clamav-unofficial-sigs

--- a/safe_filefield/tests/test_validators.py
+++ b/safe_filefield/tests/test_validators.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import Mock
 
 import clamd
 import pytest
@@ -83,6 +84,15 @@ class TestFileContentTypeValidator:
 
         with pytest.raises(ValidationError):
             validator(f)
+
+    def test_not_uploadedfile_instance(self):
+        f = get_uploaded_file(get_extras_file('sample.jpg'))
+        m = Mock()
+        m._get_file = lambda: f
+
+        validator = FileContentTypeValidator()
+
+        validator(m)
 
 
 CLAMAV_SOCKET = os.environ.get('CLAMAV_SOCKET', 'unix:///tmp/clamd.sock')

--- a/safe_filefield/validators.py
+++ b/safe_filefield/validators.py
@@ -57,6 +57,9 @@ class FileContentTypeValidator:
             self.code = code
 
     def __call__(self, file):
+        if hasattr(file, '_get_file'):
+            file = file._get_file()
+
         __, ext = os.path.splitext(file.name)
 
         detected_content_type = detect_content_type(file)


### PR DESCRIPTION
Looks like there are cases where `FileContentTypeValidator` receives a [`FieldFile`](https://docs.djangoproject.com/en/2.2/ref/models/fields#django.db.models.fields.files.FieldFile) object that does not have a `content_type` attribute. Attempts to fix issue #4 by getting the `UploadedFile` instance from a `FieldFile` object.

(adds Django 2.x to test matrix)